### PR TITLE
feat: add editable pages collection

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2,9 +2,9 @@ backend:
   name: github
   repo: waynelan828/DafengWEB
   branch: main
-  site_domain: nice8.work 
+  site_domain: nice8.work
   base_url: https://nice8.work # Your site domain
-  
+
   auth_endpoint: /oauth
 
 media_folder: 'public/images/uploads'
@@ -20,3 +20,24 @@ collections:
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Date', name: 'date', widget: 'datetime' }
       - { label: 'Body', name: 'body', widget: 'markdown' }
+  - name: 'pages'
+    label: 'Pages'
+    files:
+      - label: 'About Page'
+        name: 'about'
+        file: 'src/pages/about.astro'
+        fields:
+          - { label: 'Title', name: 'title', widget: 'string' }
+          - { label: 'Body', name: 'body', widget: 'text' }
+      - label: 'Contact Page'
+        name: 'contact'
+        file: 'src/pages/contact.astro'
+        fields:
+          - { label: 'Title', name: 'title', widget: 'string' }
+          - { label: 'Body', name: 'body', widget: 'text' }
+      - label: 'Privacy Policy'
+        name: 'privacy'
+        file: 'src/pages/privacy.md'
+        fields:
+          - { label: 'Title', name: 'title', widget: 'string' }
+          - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,8 +6,10 @@ import Stats from '~/components/widgets/Stats.astro';
 import Steps2 from '~/components/widgets/Steps2.astro';
 import Layout from '~/layouts/PageLayout.astro';
 
+const title = 'About us';
+const body = `Update this copy from Netlify CMS to describe your company.`;
 const metadata = {
-  title: 'About us',
+  title,
 };
 ---
 
@@ -15,7 +17,7 @@ const metadata = {
   <!-- Hero Widget ******************* -->
 
   <Hero
-    tagline="About us"
+    tagline={title}
     image={{
       src: 'https://images.unsplash.com/photo-1559136555-9303baea8ebd?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
       alt: 'Caos Image',
@@ -32,6 +34,10 @@ const metadata = {
       Suspendisse vitae nisi eget tortor luctus maximus sed non lectus.
     </Fragment>
   </Hero>
+
+  <div class="prose mx-auto my-8">
+    {body}
+  </div>
 
   <!-- Stats Widget ****************** -->
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,15 +4,21 @@ import HeroText from '~/components/widgets/HeroText.astro';
 import ContactUs from '~/components/widgets/Contact.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 
+const title = 'Contact';
+const body = `Use the form below to reach out to our team.`;
 const metadata = {
-  title: 'Contact',
+  title,
 };
 ---
 
 <Layout metadata={metadata}>
   <!-- HeroText Widget ******************* -->
 
-  <HeroText tagline="Contact" title="Let's Connect!" />
+  <HeroText tagline={title} title="Let's Connect!" />
+
+  <div class="prose mx-auto my-8">
+    {body}
+  </div>
 
   <ContactUs
     id="form"


### PR DESCRIPTION
## Summary
- add Netlify CMS collection for site pages using files strategy
- expose title and body fields in About and Contact Astro pages for CMS editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: astro.config.ts:37:12 - error ts(2554): Expected 1 arguments, but got 0.)*
- `npx prettier -w public/admin/config.yml src/pages/about.astro src/pages/contact.astro`


------
https://chatgpt.com/codex/tasks/task_e_68c188b6c99883249199e61c9d650844