### PR TITLE
Remove Astro announcement banner

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,7 +2,6 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Footer from '~/components/widgets/Footer.astro';
-import Announcement from '~/components/widgets/Announcement.astro';
 
 import { headerData, footerData } from '~/navigation';
 
@@ -16,9 +15,7 @@ const { metadata } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
-  <slot name="announcement">
-    <Announcement />
-  </slot>
+  <slot name="announcement" />
   <slot name="header">
     <Header {...headerData} isSticky showRssFeed showToggleTheme />
   </slot>


### PR DESCRIPTION
## Summary
- remove default announcement banner from `PageLayout`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Expected 1 arguments, but got 0)


------
https://chatgpt.com/codex/tasks/task_e_68c819412d78832498241d9c8c848000