### PR TITLE
Update hero components for full-width home banner

### DIFF
--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -24,7 +24,7 @@ const {
       {bg ? <Fragment set:html={bg} /> : null}
     </slot>
   </div>
-  <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="relative w-full px-4 sm:px-6">
     <div class="pt-0 md:pt-[76px] pointer-events-none"></div>
     <div class="py-12 md:py-20">
       <div class="text-center pb-10 md:pb-16 max-w-5xl mx-auto">
@@ -76,7 +76,7 @@ const {
       >
         {
           image && (
-            <div class="relative m-auto max-w-5xl">
+            <div class="relative w-full">
               {typeof image === 'string' ? (
                 <Fragment set:html={image} />
               ) : (

--- a/src/components/widgets/Hero2.astro
+++ b/src/components/widgets/Hero2.astro
@@ -24,7 +24,7 @@ const {
       {bg ? <Fragment set:html={bg} /> : null}
     </slot>
   </div>
-  <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
+  <div class="relative w-full px-4 sm:px-6">
     <div class="pt-0 md:pt-[76px] pointer-events-none"></div>
     <div class="py-12 md:py-20 lg:py-0 lg:flex lg:items-center lg:h-screen lg:gap-8">
       <div class="basis-1/2 text-center lg:text-left pb-10 md:pb-16 mx-auto">
@@ -75,7 +75,7 @@ const {
       <div class="basis-1/2">
         {
           image && (
-            <div class="relative m-auto max-w-5xl intersect-once intersect-no-queue motion-safe:md:intersect:animate-fade motion-safe:md:opacity-0 intersect-quarter">
+            <div class="relative w-full intersect-once intersect-no-queue motion-safe:md:intersect:animate-fade motion-safe:md:opacity-0 intersect-quarter">
               {typeof image === 'string' ? (
                 <Fragment set:html={image} />
               ) : (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '~/layouts/PageLayout.astro';
 
-import Hero from '~/components/widgets/Hero.astro';
+import Hero2 from '~/components/widgets/Hero2.astro';
 import Features from '~/components/widgets/Features.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Steps2 from '~/components/widgets/Steps2.astro';
@@ -21,7 +21,7 @@ const metadata = {
 <Layout metadata={metadata}>
   <!-- Hero：首頁主視覺 -->
 
-  <Hero
+  <Hero2
     actions={[
       { variant: 'primary', text: '預約現勘/估價', href: '/contact', icon: 'tabler:calendar-check' },
       { text: '看作品集', href: '/portfolio' },
@@ -35,7 +35,7 @@ const metadata = {
       設計師與屋主指定的施工夥伴｜從丈量、報價、進度控管到完工保固，
       一次到位的專業團隊。
     </Fragment>
-  </Hero>
+  </Hero2>
 
   <!-- 核心優勢 -->
 


### PR DESCRIPTION
## Summary
- remove the max-width wrappers from the hero widgets so images can span the viewport
- keep the full-height behavior in Hero2 and swap the homepage to use the updated component for a full-bleed banner

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c8d51565988324a75ae2c667840427