### PR TITLE
Update Netlify adapter image configuration

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,7 +11,7 @@ import icon from 'astro-icon';
 import compress from 'astro-compress';
 import type { AstroIntegration } from 'astro';
 
-import netlify from '@astrojs/netlify/functions';     // 🚀 Netlify adapter
+import netlify from '@astrojs/netlify';     // 🚀 Netlify adapter
 import decapCmsOauth from 'astro-decap-cms-oauth';    // 🚀 Decap CMS OAuth
 import astrowind from './vendor/integration';
 
@@ -88,6 +88,9 @@ export default defineConfig({
   site: 'https://nice8.works',
 
   image: {
+    service: {
+      entrypoint: '@astrojs/netlify/image-service',
+    },
     domains: ['cdn.pixabay.com'],
   },
 


### PR DESCRIPTION
## Summary
- switch the Netlify adapter import to use the top-level package while keeping the adapter setup
- configure Astro image settings to use Netlify's image service and allow cdn.pixabay.com

## Testing
- npm run dev *(fails: missing OAUTH_GITHUB_CLIENT_ID and OAUTH_GITHUB_CLIENT_SECRET environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c8dd1e39688324b92e5b22ed15b84b