### PR TITLE
Adjust hero hero image container width

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,7 +11,7 @@ import icon from 'astro-icon';
 import compress from 'astro-compress';
 import type { AstroIntegration } from 'astro';
 
-import netlify from '@astrojs/netlify/functions';     // 🚀 Netlify adapter
+import netlify from '@astrojs/netlify';     // 🚀 Netlify adapter
 import decapCmsOauth from 'astro-decap-cms-oauth';    // 🚀 Decap CMS OAuth
 import astrowind from './vendor/integration';
 

--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -76,7 +76,7 @@ const {
       >
         {
           image && (
-            <div class="relative m-auto max-w-5xl">
+            <div class="relative w-full -mx-4 sm:-mx-6">
               {typeof image === 'string' ? (
                 <Fragment set:html={image} />
               ) : (


### PR DESCRIPTION
## Summary
- allow the hero image container to span the full width of the layout by replacing the fixed max-width and offsetting the page padding
- update the Netlify adapter import to the supported entrypoint so Astro check no longer errors

## Testing
- npm run check:astro

------
https://chatgpt.com/codex/tasks/task_e_68c8df719a808324bcc9b4230b80650f