### PR TITLE
feat: add footer social links

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -36,7 +36,18 @@ export const footerData = {
     { text: '條款', href: getPermalink('/terms') },
     { text: '隱私權政策', href: getPermalink('/privacy') },
   ],
-  socialLinks: [],
+  socialLinks: [
+    {
+      ariaLabel: 'Facebook',
+      icon: 'tabler:brand-facebook',
+      href: 'https://facebook.com/nice8works',
+    },
+    {
+      ariaLabel: 'Instagram',
+      icon: 'tabler:brand-instagram',
+      href: 'https://instagram.com/nice8works',
+    },
+  ],
   footNote: `
     © 大鋒工程 Da Feng Interior · All rights reserved.
   `,


### PR DESCRIPTION
## Summary
- add Facebook and Instagram social icons to the footer social links list

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c905c5df408324ac5bd1daaa844f3a