### PR TITLE
Fix hero banner image scaling

### DIFF
--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -83,12 +83,12 @@ const {
                 <Fragment set:html={image} />
               ) : (
                 <Image
-                  class="w-screen object-cover"
-                  widths={[400, 768, 1024, 2040]}
-                  sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
+                  class="w-full object-cover"
+                  widths={[640, 960, 1280, 1536]}
+                  sizes="100vw"
                   loading="eager"
-                  width={1024}
-                  height={576}
+                  width={1536}
+                  height={1024}
                   {...image}
                 />
               )}


### PR DESCRIPTION
## Summary
- update the hero banner to use the source image proportions so it no longer appears stretched
- adjust responsive sizing so the hero image spans the full width of the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c90b144248832481a365487670d1bc