### PR TITLE
Add homepage link to navigation menus

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -2,6 +2,7 @@ import { getPermalink, getBlogPermalink } from './utils/permalinks';
 
 export const headerData = {
   links: [
+    { text: '首頁', href: getPermalink('/') },
     { text: '關於我們', href: getPermalink('/about') },
     { text: '服務項目', href: getPermalink('/services') },
     { text: '專案案例', href: getPermalink('/portfolio') },
@@ -16,6 +17,7 @@ export const footerData = {
     {
       title: '網站導覽',
       links: [
+        { text: '首頁', href: getPermalink('/') },
         { text: '關於我們', href: getPermalink('/about') },
         { text: '服務項目', href: getPermalink('/services') },
         { text: '專案案例', href: getPermalink('/portfolio') },


### PR DESCRIPTION
## Summary
- add a homepage link at the beginning of the header navigation
- include the homepage link in the footer site map section

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68c92107f51c832499b0fb4933ae4e53