### PR TITLE
Add fixed CTA floating button

### DIFF
--- a/src/components/ui/FixedCTA.astro
+++ b/src/components/ui/FixedCTA.astro
@@ -1,0 +1,23 @@
+---
+import { Icon } from 'astro-icon/components';
+---
+
+<div class="fixed-cta">
+  <a href="#" class="btn-primary shadow-lg gap-2" aria-label="預約估價">
+    <Icon name="simple-icons:line" class="w-5 h-5" aria-hidden="true" />
+    <span>預約估價</span>
+  </a>
+</div>
+
+<style>
+  .fixed-cta {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 50;
+  }
+
+  .fixed-cta a {
+    gap: 0.5rem;
+  }
+</style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,6 +2,7 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Footer from '~/components/widgets/Footer.astro';
+import FixedCTA from '~/components/ui/FixedCTA.astro';
 
 import { headerData, footerData } from '~/navigation';
 
@@ -26,4 +27,5 @@ const { metadata } = Astro.props;
   <slot name="footer">
     <Footer {...footerData} />
   </slot>
+  <FixedCTA />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,8 @@ import Hero from '~/components/widgets/Hero.astro';
 import Features from '~/components/widgets/Features.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Steps2 from '~/components/widgets/Steps2.astro';
-import Content from '~/components/widgets/Content.astro';
 import Testimonials from '~/components/widgets/Testimonials.astro';
 import FAQs from '~/components/widgets/FAQs.astro';
-import CallToAction from '~/components/widgets/CallToAction.astro';
 import ItemGrid from '~/components/ui/ItemGrid.astro';
 
 const metadata = {
@@ -22,10 +20,6 @@ const metadata = {
   <!-- Hero：首頁主視覺 -->
 
   <Hero
-    actions={[
-      { variant: 'primary', text: '預約現勘/估價', href: '/contact', icon: 'tabler:calendar-check' },
-      { text: '看作品集', href: '/portfolio' },
-    ]}
     image={{ src: '~/assets/images/hero-image.png', alt: '大鋒工程 室內裝修與木作' }}
   >
     <Fragment slot="title">
@@ -222,12 +216,5 @@ const metadata = {
     ]}
   />
 
-  <!-- 行動呼籲 -->
-  <CallToAction
-    actions={[{ variant: 'primary', text: '免費諮詢與現勘', href: '/contact' }]}
-  >
-    <Fragment slot="title">把想要的家，交給專業團隊</Fragment>
-    <Fragment slot="subtitle">留下您的需求與聯絡方式，我們 1–2 個工作日回覆。</Fragment>
-  </CallToAction>
 </Layout>
 


### PR DESCRIPTION
## Summary
- add a fixed CTA component with a Line icon button for quick quotes
- render the floating CTA from the shared page layout so it appears sitewide
- clean up the homepage hero and remove the old call-to-action section

## Testing
- npm run check *(fails: existing eslint unused-variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c92759700c83249e979d03eb1eff3c