### PR TITLE
Add Simple Icons icon set and include line icon

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
           'business-contact',
           'database',
         ],
+        'simple-icons': ['line'],
       },
     }),
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
                             "@eslint/js":  "^9.33.0",
                             "@iconify-json/flat-color-icons":  "^1.2.1",
                             "@iconify-json/tabler":  "^1.2.20",
+                            "@iconify-json/simple-icons":  "^1.2.7",
                             "@tailwindcss/typography":  "^0.5.16",
                             "@types/js-yaml":  "^4.0.9",
                             "@types/lodash.merge":  "^4.6.9",


### PR DESCRIPTION
## Summary
- add the `@iconify-json/simple-icons` package to development dependencies
- expose the Simple Icons Line glyph through the Astro Icon configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c92b99938c83248d2f3ca3b1e828e6