### PR TITLE
Adjust fixed CTA offset to avoid footer overlap

### DIFF
--- a/src/components/ui/FixedCTA.astro
+++ b/src/components/ui/FixedCTA.astro
@@ -12,7 +12,7 @@ import { Icon } from 'astro-icon/components';
 <style>
   .fixed-cta {
     position: fixed;
-    bottom: 1rem;
+    bottom: 4rem;
     right: 1rem;
     z-index: 50;
   }


### PR DESCRIPTION
## Summary
- raise the fixed CTA's bottom offset so it clears the footer links

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c92effb2608324be98b629cd319295