### PR TITLE
fix: link fixed cta to contact form

### DIFF
--- a/src/components/ui/FixedCTA.astro
+++ b/src/components/ui/FixedCTA.astro
@@ -3,7 +3,7 @@ import { Icon } from 'astro-icon/components';
 ---
 
 <div class="fixed-cta">
-  <a href="/contact" class="cta-booking" aria-label="預約估價">
+  <a href="/contact#form" class="cta-booking" aria-label="預約估價">
     <span>預約估價</span>
   </a>
   <a


### PR DESCRIPTION
## Summary
- update the fixed CTA button to link directly to the contact form section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9447300b08324b499349900cab3d8