### PR TITLE
移除 RSS 按鈕並移動社群按鈕至右上角

### DIFF
--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -5,8 +5,7 @@ import ToggleTheme from '~/components/common/ToggleTheme.astro';
 import ToggleMenu from '~/components/common/ToggleMenu.astro';
 import Button from '~/components/ui/Button.astro';
 
-import { getHomePermalink } from '~/utils/permalinks';
-import { trimSlash, getAsset } from '~/utils/permalinks';
+import { getHomePermalink, trimSlash } from '~/utils/permalinks';
 import type { CallToAction } from '~/types';
 
 interface Link {
@@ -28,8 +27,8 @@ export interface Props {
   isDark?: boolean;
   isFullWidth?: boolean;
   showToggleTheme?: boolean;
-  showRssFeed?: boolean;
   position?: string;
+  socialLinks?: Array<Link>;
 }
 
 const {
@@ -40,8 +39,8 @@ const {
   isDark = false,
   isFullWidth = false,
   showToggleTheme = false,
-  showRssFeed = false,
   position = 'center',
+  socialLinks = [],
 } = Astro.props;
 
 const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
@@ -138,17 +137,16 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       <div class="items-center flex justify-between w-full md:w-auto">
         <div class="flex">
           {showToggleTheme && <ToggleTheme iconClass="w-6 h-6 md:w-5 md:h-5 md:inline-block" />}
-          {
-            showRssFeed && (
-              <a
-                class="text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
-                aria-label="RSS Feed"
-                href={getAsset('/rss.xml')}
-              >
-                <Icon name="tabler:rss" class="w-5 h-5" />
-              </a>
-            )
-          }
+          {socialLinks.map(({ ariaLabel, href, icon, text }) => (
+            <a
+              class="text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+              aria-label={ariaLabel}
+              href={href}
+            >
+              {icon && <Icon name={icon} class="w-5 h-5" />}
+              {text}
+            </a>
+          ))}
         </div>
         {
           actions?.length ? (

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -19,7 +19,7 @@ const { metadata } = Astro.props;
   <slot name="announcement" />
   <slot name="header">
     <!-- Align header like the AstroWind template (logo + nav left, actions right) -->
-    <Header {...headerData} isSticky showRssFeed showToggleTheme position="right" />
+    <Header {...headerData} isSticky showToggleTheme position="right" />
   </slot>
   <main>
     <slot />

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -10,6 +10,18 @@ export const headerData = {
     { text: '聯絡我們', href: getPermalink('/contact') },
   ],
   actions: [],
+  socialLinks: [
+    {
+      ariaLabel: 'Facebook',
+      icon: 'tabler:brand-facebook',
+      href: 'https://facebook.com/nice8works',
+    },
+    {
+      ariaLabel: 'Instagram',
+      icon: 'tabler:brand-instagram',
+      href: 'https://instagram.com/nice8works',
+    },
+  ],
 };
 
 export const footerData = {


### PR DESCRIPTION
## 摘要
- 將導覽列的 RSS 按鈕移除
- 將社群媒體按鈕加入並移至頁面右上角

## 測試
- `npm test`（找不到 test script）
- `npm run check`（lint 錯誤）
- `npm run build`（缺少環境變數）

------
https://chatgpt.com/codex/tasks/task_e_68c945273df083249aaaca1057666f31