### PR TITLE
註解頁面主題切換按鈕

### DIFF
--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -26,9 +26,9 @@ const { metadata } = Astro.props;
             href: 'https://github.com/arthelokyo/astrowind',
           },
         ]}
-        showToggleTheme
+        showToggleTheme={false}
         position="right"
-      />
+      /> <!-- showToggleTheme：主題切換按鈕，如需再次顯示請將此屬性設為 true 並移除此註解 -->
     </slot>
   </Fragment>
   <slot />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -19,7 +19,7 @@ const { metadata } = Astro.props;
   <slot name="announcement" />
   <slot name="header">
     <!-- Align header like the AstroWind template (logo + nav left, actions right) -->
-    <Header {...headerData} isSticky showToggleTheme position="right" />
+    <Header {...headerData} isSticky showToggleTheme={false} position="right" /> <!-- showToggleTheme：主題切換按鈕，如需再次顯示請將此屬性設為 true 並移除此註解 -->
   </slot>
   <main>
     <slot />


### PR DESCRIPTION
## Summary
- 在 PageLayout 與 LandingLayout 中以註解方式停用 `showToggleTheme` 屬性，並加上中文說明方便日後恢復。

## Testing
- `npm test` *(Missing script: "test")*
- `npm run check` *(eslint: scripts/generate-brand-assets.mjs 等既有程式存在錯誤)*

------
https://chatgpt.com/codex/tasks/task_e_68c94dbc5a148324a7a91cab762249fc