### PR TITLE
feat: adjust hero carousel autoplay and pagination

### DIFF
--- a/src/components/widgets/HeroCarousel.astro
+++ b/src/components/widgets/HeroCarousel.astro
@@ -65,7 +65,11 @@ const normalizedSlides = slides
           autoplay-disable-on-interaction="false"
           autoplay-pause-on-mouse-enter="true"
           {...(loop ? { loop: 'true' } : { loop: 'false' })}
-          {...(pagination ? { pagination: 'true' } : { pagination: 'false' })}
+          {...
+            pagination
+              ? { pagination: 'true', 'pagination-clickable': 'true' }
+              : { pagination: 'false', 'pagination-clickable': 'false' }
+          }
         >
           {normalizedSlides.map((slide) => {
             const { src, alt, ...imageProps } = slide.image;
@@ -152,5 +156,15 @@ const normalizedSlides = slides
 
   :global(swiper-container.hero-carousel swiper-slide) {
     display: block;
+  }
+
+  :global(swiper-container.hero-carousel .swiper-pagination-bullet) {
+    cursor: pointer;
+    pointer-events: auto;
+  }
+
+  :global(swiper-container.hero-carousel::part(bullet)) {
+    cursor: pointer;
+    pointer-events: auto;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,7 @@ const metadata = {
   <!-- Hero：首頁主視覺 -->
 
   <HeroCarousel
+    autoplayDelay={7000}
     slides={[
       {
         image: {


### PR DESCRIPTION
## Summary
- set the homepage hero carousel to rotate every seven seconds
- enable clickable pagination bullets and apply a pointer cursor for the hero carousel

## Testing
- npm run check *(fails: existing eslint errors in Favicons.astro, about.astro and scripts/generate-brand-assets.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c9504f42a083248a2df1245b1374f7