### PR TITLE
Fix Swiper asset loading by using static includes

### DIFF
--- a/src/components/widgets/HeroCarousel.astro
+++ b/src/components/widgets/HeroCarousel.astro
@@ -58,7 +58,6 @@ const normalizedSlides = slides
       <div class="relative w-full">
         <div class="pt-0 md:pt-[76px] pointer-events-none" />
         <swiper-container
-          ref={el => (swiperRef = el)}
           class="hero-carousel relative block h-screen w-full"
           effect="fade"
           speed="800"
@@ -133,30 +132,6 @@ const normalizedSlides = slides
   )
 }
 
-<script is:inline>
-  let swiperRef: HTMLElement | null = null;
-
-  if (typeof window !== 'undefined') {
-    const styleId = 'aw-swiper-style';
-    const scriptId = 'aw-swiper-script';
-
-    if (!document.getElementById(styleId)) {
-      const link = document.createElement('link');
-      link.id = styleId;
-      link.rel = 'stylesheet';
-      link.href = '/vendor/swiper/swiper-bundle.min.css';
-      document.head.appendChild(link);
-    }
-
-    if (!customElements.get('swiper-container') && !document.getElementById(scriptId)) {
-      const script = document.createElement('script');
-      script.id = scriptId;
-      script.src = '/vendor/swiper/swiper-element-bundle.min.js';
-      script.defer = true;
-      document.head.appendChild(script);
-    }
-  }
-</script>
 
 <style>
   :global(swiper-container.hero-carousel) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,6 +38,8 @@ const { language, textDirection } = I18N;
 
     <!-- Comment the line below to disable View Transitions -->
     <ClientRouter fallback="swap" />
+
+    <slot name="head" />
   </head>
 
   <body class="antialiased text-default bg-page tracking-tight">

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -16,6 +16,10 @@ const { metadata } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
+  <Fragment slot="head">
+    <link rel="stylesheet" href="/vendor/swiper/swiper-bundle.min.css" />
+    <script src="/vendor/swiper/swiper-element-bundle.min.js" defer></script>
+  </Fragment>
   <slot name="announcement" />
   <slot name="header">
     <!-- Align header like the AstroWind template (logo + nav left, actions right) -->


### PR DESCRIPTION
## Summary
- allow layouts to accept additional head content and provide Swiper assets globally
- include the Swiper CSS/JS statically from PageLayout so the carousel can load without dynamic injection
- remove the runtime DOM manipulation in HeroCarousel now that the assets load from the head

## Testing
- npm run build *(fails: missing `@iconify-json/simple-icons` collection during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68c97bcf67988324897ad6d2f84c2407