### PR TITLE
Hide default swiper arrow pseudo elements

### DIFF
--- a/src/components/widgets/HeroCarousel.astro
+++ b/src/components/widgets/HeroCarousel.astro
@@ -150,6 +150,11 @@ const normalizedSlides = slides
     pointer-events: auto;
   }
 
+  :global(swiper-container.hero-carousel .swiper-button-prev::after),
+  :global(swiper-container.hero-carousel .swiper-button-next::after) {
+    display: none;
+  }
+
   :global(swiper-container.hero-carousel::part(bullet)) {
     cursor: pointer;
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- hide the default Swiper navigation pseudo-element icons in the hero carousel styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c981bbde3c83249593fea55910b07c