### PR TITLE
fix: replace invalid blueprint icon

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,7 +20,7 @@ const teamHighlights: Array<Item> = [
   {
     title: '深厚圖面判讀能力',
     description: '精通施工圖與材質規劃，能精準轉譯設計藍圖並規畫可行的施工工法。',
-    icon: 'tabler:blueprint',
+    icon: 'tabler:layout-2',
   },
   {
     title: '跨團隊協作專長',


### PR DESCRIPTION
## Summary
- replace the invalid Tabler blueprint icon slug on the about page with the existing layout-2 icon

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ca7bfb86cc83249035598dd0fb216b