### PR TITLE
fix: correct about page integrity icon

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -61,7 +61,7 @@ const cultureItems: Array<Item> = [
   {
     title: '誠信',
     description: '以誠懇透明的態度面對每位設計師與客戶，建立長期信任關係並確保進度公開。',
-    icon: 'tabler:handshake',
+    icon: 'tabler:heart-handshake',
   },
   {
     title: '品質',


### PR DESCRIPTION
## Summary
- update the "誠信" culture entry on the about page to use the available Tabler `heart-handshake` icon

## Testing
- npm run dev -- --host 0.0.0.0 --port 4321 *(fails: missing env variables `OAUTH_GITHUB_CLIENT_ID` and `OAUTH_GITHUB_CLIENT_SECRET` required by astro-decap-cms-oauth)*

------
https://chatgpt.com/codex/tasks/task_e_68ca823c9bcc83248201be539d24a1ba