### PR TITLE
Fix about page integrity icon reference

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -61,7 +61,7 @@ const cultureItems: Array<Item> = [
   {
     title: '誠信',
     description: '以誠懇透明的態度面對每位設計師與客戶，建立長期信任關係並確保進度公開。',
-    icon: 'tabler:handshake',
+    icon: 'tabler:heart-handshake',
   },
   {
     title: '品質',


### PR DESCRIPTION
## Summary
- update the integrity culture item to use the existing `tabler:heart-handshake` icon so it renders correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cabfc00fec8324906143ff85b6d38c