### PR TITLE
Adjust hero carousel mobile navigation

### DIFF
--- a/src/components/widgets/HeroCarousel.astro
+++ b/src/components/widgets/HeroCarousel.astro
@@ -87,6 +87,7 @@ const normalizedSlides = slides
           effect="fade"
           speed="800"
           navigation="true"
+          allow-touch-move="true"
           autoplay-delay={autoplayDelay}
           autoplay-disable-on-interaction="false"
           autoplay-pause-on-mouse-enter="true"
@@ -142,11 +143,11 @@ const normalizedSlides = slides
           })}
           <div
             slot="container-end"
-            class="swiper-button-prev absolute left-0 z-20 h-full w-1/2 cursor-pointer bg-transparent"
+            class="swiper-button-prev absolute left-0 z-20 h-full w-1/2 cursor-pointer bg-transparent hidden md:block"
           />
           <div
             slot="container-end"
-            class="swiper-button-next absolute right-0 z-20 h-full w-1/2 cursor-pointer bg-transparent"
+            class="swiper-button-next absolute right-0 z-20 h-full w-1/2 cursor-pointer bg-transparent hidden md:block"
           />
         </swiper-container>
       </div>


### PR DESCRIPTION
## Summary
- enable touch-based navigation on the hero carousel while hiding desktop navigation overlays on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cac032198883249e4d25f2645aa37f